### PR TITLE
Update keyboard mode definitions

### DIFF
--- a/src/bms/model/BMSModel.java
+++ b/src/bms/model/BMSModel.java
@@ -306,26 +306,30 @@ public class BMSModel implements Comparable {
 				nlane = PMS_NORMALLANE;
 				slane = PMS_SCRATCHLANE;
 				break;
-			case KEYBOARD_24K:
-				if (side == 1) {
-					nlane = KB_24KEY_NORMALLANE_1P;
-					slane = KB_24KEY_SCRATCHLANE_1P;
-				} else if (side == 2) {
-					nlane = KB_24KEY_NORMALLANE_2P;
-					slane = KB_24KEY_SCRATCHLANE_2P;
-				} else {
-					nlane = KB_24KEY_NORMALLANE;
-					slane = KB_24KEY_SCRATCHLANE;
-				}
-				break;
-			default:
-				if (side == 1) {
-					nlane = BMS_NORMALLANE_1P;
-					slane = BMS_SCRATCHLANE_1P;
-				} else if (side == 2) {
-					nlane = BMS_NORMALLANE_2P;
-					slane = BMS_SCRATCHLANE_2P;
-				}
+		case KEYBOARD_24K:
+			if (side == 1) {
+				nlane = KB_24KEY_NORMALLANE_1P;
+				slane = KB_24KEY_SCRATCHLANE_1P;
+			} else if (side == 2) {
+				nlane = KB_24KEY_NORMALLANE_2P;
+				slane = KB_24KEY_SCRATCHLANE_2P;
+			} else {
+				nlane = KB_24KEY_NORMALLANE;
+				slane = KB_24KEY_SCRATCHLANE;
+			}
+			break;
+		case KEYBOARD_24K_DOUBLE:
+			nlane = KB_24KEY_NORMALLANE;
+			slane = KB_24KEY_SCRATCHLANE;
+			break;
+		default:
+			if (side == 1) {
+				nlane = BMS_NORMALLANE_1P;
+				slane = BMS_SCRATCHLANE_1P;
+			} else if (side == 2) {
+				nlane = BMS_NORMALLANE_2P;
+				slane = BMS_SCRATCHLANE_2P;
+			}
 		}
 		return new int[][] { nlane, slane };
 	}

--- a/src/bms/model/Mode.java
+++ b/src/bms/model/Mode.java
@@ -13,8 +13,8 @@ public enum Mode {
 	BEAT_14K(14, "beat-14k", 2, 16, new int[]{7, 15}),
 	POPN_5K(9, "popn-5k", 1, 5, new int[]{}),
 	POPN_9K(9, "popn-9k", 1, 9, new int[]{}),
-	KEYBOARD_24K(24, "keyboard-24k", 1, 26, new int[]{24, 25}),	
-	KEYBOARD_48K(48, "keyboard-24k-double", 2, 52, new int[]{24, 25, 51, 52}),	
+	KEYBOARD_24K(25, "keyboard-24k", 1, 26, new int[]{24, 25}),
+	KEYBOARD_24K_DOUBLE(50, "keyboard-24k-double", 2, 52, new int[]{24, 25, 50, 51}),
 	;
 
 	public final int id;

--- a/src/bms/model/Mode.java
+++ b/src/bms/model/Mode.java
@@ -13,8 +13,8 @@ public enum Mode {
 	BEAT_14K(14, "beat-14k", 2, 16, new int[]{7, 15}),
 	POPN_5K(9, "popn-5k", 1, 5, new int[]{}),
 	POPN_9K(9, "popn-9k", 1, 9, new int[]{}),
-	KEYBOARD_24K(24, "keyboard-24k", 1, 26, new int[]{}),
-	KEYBOARD_48K(48, "keyboard-24k-double", 2, 52, new int[]{}),
+	KEYBOARD_24K(24, "keyboard-24k", 1, 26, new int[]{24, 25}),	
+	KEYBOARD_48K(48, "keyboard-24k-double", 2, 52, new int[]{24, 25, 51, 52}),	
 	;
 
 	public final int id;

--- a/src/bms/model/Mode.java
+++ b/src/bms/model/Mode.java
@@ -13,8 +13,8 @@ public enum Mode {
 	BEAT_14K(14, "beat-14k", 2, 16, new int[]{7, 15}),
 	POPN_5K(9, "popn-5k", 1, 5, new int[]{}),
 	POPN_9K(9, "popn-9k", 1, 9, new int[]{}),
-	KEYBOARD_24K(24, "keyboard-24k", 1, 26, new int[]{24, 25}),	
-	KEYBOARD_48K(48, "keyboard-24k-double", 2, 52, new int[]{24, 25, 51, 52}),	
+	KEYBOARD_24K(24, "keyboard-24k", 1, 26, new int[]{}),
+	KEYBOARD_48K(48, "keyboard-24k-double", 2, 52, new int[]{}),
 	;
 
 	public final int id;


### PR DESCRIPTION
* Modified `KEYBOARD_24K_DOUBLE` definition.
* Modified mode ids.

----

* 今後ひょっとするとDPではない48鍵モードを追加するかもしれず、その際IDの衝突を防ぐために24鍵と24鍵DPのIDを変更しています。（一応意図としては25=24鍵盤+1ホイールというつもりです。）
* beatoraja側ではこちらでコンパイルしたものを https://github.com/exch-bms2/beatoraja/pull/83 に取り込んでいます。