### PR TITLE
Support Base 62 definition

### DIFF
--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -18,11 +18,11 @@ import static bms.model.DecodeLog.State.*;
  */
 public class BMSDecoder extends ChartDecoder {
 
-	final List<String> wavlist = new ArrayList<String>(36 * 36);
-	private final int[] wm = new int[36 * 36];
+	final List<String> wavlist = new ArrayList<String>(62 * 62);
+	private final int[] wm = new int[62 * 62];
 
-	final List<String> bgalist = new ArrayList<String>(36 * 36);
-	private final int[] bm = new int[36 * 36];
+	final List<String> bgalist = new ArrayList<String>(62 * 62);
+	private final int[] bm = new int[62 * 62];
 
 	public BMSDecoder() {
 		this(BMSModel.LNTYPE_LONGNOTE);
@@ -175,6 +175,7 @@ public class BMSDecoder extends ChartDecoder {
 						}
 					} else if (skip.isEmpty() || !skip.getLast()) {
 						final char c = line.charAt(1);
+						final int base = model.getBase();
 						if ('0' <= c && c <= '9' && line.length() > 6) {
 							// line = line.toUpperCase();
 							// 楽譜
@@ -209,7 +210,11 @@ public class BMSDecoder extends ChartDecoder {
 								try {
 									double bpm = Double.parseDouble(line.substring(7).trim());
 									if(bpm > 0) {
-										bpmtable.put(ChartDecoder.parseInt36(line, 4), bpm);
+										if(base == 62) {
+											bpmtable.put(ChartDecoder.parseInt62(line, 4), bpm);
+										} else {
+											bpmtable.put(ChartDecoder.parseInt36(line, 4), bpm);
+										}
 									} else {
 										log.add(new DecodeLog(WARNING, "#negative BPMはサポートされていません : " + line));
 									}
@@ -222,7 +227,11 @@ public class BMSDecoder extends ChartDecoder {
 							if (line.length() >= 8) {
 								try {
 									final String file_name = line.substring(7).trim().replace('\\', '/');
-									wm[ChartDecoder.parseInt36(line, 4)] = wavlist.size();
+									if(base == 62) {
+										wm[ChartDecoder.parseInt62(line, 4)] = wavlist.size();
+									} else {
+										wm[ChartDecoder.parseInt36(line, 4)] = wavlist.size();
+									}
 									wavlist.add(file_name);
 								} catch (NumberFormatException e) {
 									log.add(new DecodeLog(WARNING, "#WAVxxは不十分な定義です : " + line));
@@ -235,10 +244,14 @@ public class BMSDecoder extends ChartDecoder {
 							if (line.length() >= 8) {
 								try {
 									final String file_name = line.substring(7).trim().replace('\\', '/');
-									bm[ChartDecoder.parseInt36(line, 4)] = bgalist.size();
+									if(base == 62) {
+										bm[ChartDecoder.parseInt62(line, 4)] = bgalist.size();
+									} else {
+										bm[ChartDecoder.parseInt36(line, 4)] = bgalist.size();
+									}
 									bgalist.add(file_name);
 								} catch (NumberFormatException e) {
-									log.add(new DecodeLog(WARNING, "#WAVxxは不十分な定義です : " + line));
+									log.add(new DecodeLog(WARNING, "#BMPxxは不十分な定義です : " + line));
 								}
 							} else {
 								log.add(new DecodeLog(WARNING, "#BMPxxは不十分な定義です : " + line));
@@ -251,7 +264,11 @@ public class BMSDecoder extends ChartDecoder {
 										stop = Math.abs(stop);
 										log.add(new DecodeLog(WARNING, "#negative STOPはサポートされていません : " + line));
 									}
-									stoptable.put(ChartDecoder.parseInt36(line, 5), stop);
+									if(base == 62) {
+										stoptable.put(ChartDecoder.parseInt62(line, 5), stop);
+									} else {
+										stoptable.put(ChartDecoder.parseInt36(line, 5), stop);
+									}
 								} catch (NumberFormatException e) {
 									log.add(new DecodeLog(WARNING, "#STOPxxに数字が定義されていません : " + line));
 								}
@@ -262,7 +279,11 @@ public class BMSDecoder extends ChartDecoder {
 							if (line.length() >= 11) {
 								try {
 									double scroll = Double.parseDouble(line.substring(10).trim());
-									scrolltable.put(ChartDecoder.parseInt36(line, 7), scroll);
+									if(base == 62) {
+										scrolltable.put(ChartDecoder.parseInt62(line, 7), scroll);
+									} else {
+										scrolltable.put(ChartDecoder.parseInt36(line, 7), scroll);
+									}
 								} catch (NumberFormatException e) {
 									log.add(new DecodeLog(WARNING, "#SCROLLxxに数字が定義されていません : " + line));
 								}
@@ -551,9 +572,13 @@ enum CommandWord {
 	LNOBJ {
 		public DecodeLog execute(BMSModel model, String arg) {
 			try {
-				model.setLnobj(Integer.parseInt(arg.toUpperCase(), 36));
+				if (model.getBase() == 62) {
+					model.setLnobj(ChartDecoder.parseInt62(arg, 0));
+				} else {
+					model.setLnobj(Integer.parseInt(arg.toUpperCase(), 36));
+				}
 			} catch (NumberFormatException e) {
-				return new DecodeLog(WARNING, "#PLAYERに数字が定義されていません");
+				return new DecodeLog(WARNING, "#LNOBJに数字が定義されていません");
 			}
 			return null;
 		}
@@ -567,7 +592,7 @@ enum CommandWord {
 				}
 				model.setLnmode(lnmode);
 			} catch (NumberFormatException e) {
-				return new DecodeLog(WARNING, "#PLAYERに数字が定義されていません");
+				return new DecodeLog(WARNING, "#LNMODEに数字が定義されていません");
 			}
 			return null;
 		}
@@ -591,6 +616,20 @@ enum CommandWord {
 	COMMENT {
 		public DecodeLog execute(BMSModel model, String arg) {
 			// TODO 未実装
+			return null;
+		}
+	},
+	BASE {
+		public DecodeLog execute(BMSModel model, String arg) {
+			try {
+				int base = Integer.parseInt(arg);
+				if(base != 62) {
+					return new DecodeLog(WARNING, "#BASEに無効な数字が定義されています");
+				}
+				model.setBase(base);
+			} catch (NumberFormatException e) {
+				return new DecodeLog(WARNING, "#BASEに数字が定義されていません");
+			}
 			return null;
 		}
 	};

--- a/src/bms/model/BMSModel.java
+++ b/src/bms/model/BMSModel.java
@@ -97,6 +97,10 @@ public class BMSModel implements Comparable {
 	 * BGA定義のIDとファイル名のマップ
 	 */
 	private String[] bgamap = new String[0];
+	/**
+	 * 進数指定
+	 */
+	private int base = 36;
 
 	private int lnmode = LongNote.TYPE_UNDEFINED;
 
@@ -579,5 +583,18 @@ public class BMSModel implements Comparable {
 
 	public enum TotalType {
 		BMS, BMSON;
+	}
+
+	public int getBase() {
+		return base;
+	}
+
+	public void setBase(int base) {
+		if (base == 62) {
+			this.base = base;
+		} else {
+			this.base = 36;
+		}
+		return;
 	}
 }

--- a/src/bms/model/ChartDecoder.java
+++ b/src/bms/model/ChartDecoder.java
@@ -99,6 +99,59 @@ public abstract class ChartDecoder {
 		return result;
 	}
 
+	public static int parseInt62(String s, int index) throws NumberFormatException {
+		int result = parseInt62(s.charAt(index), s.charAt(index + 1));
+		if (result == -1) {
+			throw new NumberFormatException();
+		}
+		return result;
+	}
+
+	public static int parseInt62(char c1, char c2) {
+		int result = 0;
+		if (c1 >= '0' && c1 <= '9') {
+			result = (c1 - '0') * 62;
+		} else if (c1 >= 'A' && c1 <= 'Z') {
+			result = ((c1 - 'A') + 10) * 62;
+		} else if (c1 >= 'a' && c1 <= 'z') {
+			result = ((c1 - 'a') + 36) * 62;
+		} else {
+			return -1;
+		}
+
+		if (c2 >= '0' && c2 <= '9') {
+			result += (c2 - '0');
+		} else if (c2 >= 'A' && c2 <= 'Z') {
+			result += (c2 - 'A') + 10;
+		} else if (c2 >= 'a' && c2 <= 'z') {
+			result += (c2 - 'a') + 36;
+		} else {
+			return -1;
+		}
+
+		return result;
+	}
+
+	public static String toBase62(int decimal) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0;i < 2;i++) {
+			int mod = (int)(decimal % 62);
+			if (mod < 10) {
+				sb.append(mod);
+			} else if (mod < 36) {
+				mod = mod - 10 + 'A';
+				sb.append((char) mod);
+			} else if (mod < 62) {
+				mod = mod - 36 + 'a';
+				sb.append((char) mod);
+			} else {
+				sb.append("0");
+			}
+			decimal = (int)(decimal / 62);
+		}
+		return new String(sb.reverse());
+	}
+
 	public static class TimeLineCache {
 		
 		public final double time;


### PR DESCRIPTION
これまでのBMSでファイル定義が36進数だった部分を拡張し、大文字小文字を区別する62進数を読み込めるようにしました。
これにより使えるファイルの最大数は1295から3843へと大幅に増えます。
そのことによってBMSの可能性を高めると同時にbeatorajaの魅力も増大させることができると思います。
導入を検討していただけたら幸いです。


自身への備忘録も踏まえて重要な点をいくつか。

・既存のBMSの読み込みには影響を与えません。
変更の肝です。本来BMSの記述は大文字小文字を区別しません。
つまり断りがなければ36進数で読まれるべきです。
そこで62進数で読み込むためのコマンドを追加しました。
#BASE 62
この記述を見つけた場合にのみ62進数で #WAV や #BMP を定義します。

・いくつかのチャンネルは62進数に変更しません。
ch03（旧式BPM変更）：FFを最大とする16進数と定義されています。このチャンネルは現在も16進数と扱われており、今回の変更でも影響しません。（Section.java 98行）
chD*,E*（地雷）：ZZを最大（本来はその場でゲームオーバー）とする36進数ダメージと定義されています。このチャンネルもそのままであるべきと思い影響しないようにしました。（Section.java 489行）


それらの重点も踏まえて62進数を使用した簡単なサンプルBMSを用意しました。
詳細はBMSファイルそのものに記述しています。
検証にご利用ください。
https://nekokan.dyndns.info/file/base62sample.zip (68KB)
