### PR TITLE
BMSONDecoder: fix "up" release sound notes not working under a certain condition

### DIFF
--- a/src/bms/model/BMSONDecoder.java
+++ b/src/bms/model/BMSONDecoder.java
@@ -226,9 +226,9 @@ public class BMSONDecoder extends ChartDecoder {
 								break;
 							}
 						}
-						if(!assigned) {
-							lnup.put(n, new LongNote(id, starttime, duration));
-						}
+					}
+					if(!assigned) {
+						lnup.put(n, new LongNote(id, starttime, duration));
 					}
 				} else {
 					boolean insideln = false;


### PR DESCRIPTION
fixes a bug with release sound notes at the end of long notes (sometimes they get skipped because lnlist is null)