### PR TITLE
Support UTF Encoding

### DIFF
--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -1,6 +1,8 @@
 package bms.model;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.charset.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestInputStream;
@@ -110,9 +112,9 @@ public class BMSDecoder extends ChartDecoder {
 		String encoding = "MS932";
 		// Detect the Encoding
 		try (FileInputStream fis = new FileInputStream(path.toFile())) {
-            byte[] bytes = new byte[4];
-            fis.read(bytes, 0, 4);
-            encoding = encodingFromBOM(bytes);
+            byte[] bytes = new byte[1024];
+            fis.read(bytes, 0, 1024);
+            encoding = detectEncoding(bytes);
 		} catch (IOException e) {
 			log.add(new DecodeLog(ERROR, "BMSファイルへのアクセスに失敗しました"));
 			Logger.getGlobal()
@@ -508,6 +510,71 @@ public class BMSDecoder extends ChartDecoder {
 
         // BOMが見つからない場合、"MS932"を返す。
         return "MS932";
+    }
+
+    /**
+     * 文字化けを調べて、Charsetを推測する。
+     * @param bytes Charsetを調べるByte列。
+     * @return 登録されているCharsetごとに、Byte列を文字列化した後さらにByte列に逆変換して、
+     * 一致するなら、そのCharsetの名称。
+     * 最後まで見つからなかったら、MS932を返す。
+     */
+    public String encodingFromGarbled(byte[] bytes) {
+        List<Charset> encodingsToTry = new ArrayList<>();
+        encodingsToTry.add(Charset.forName("MS932")); // SHIFT-JISは最優先する
+        encodingsToTry.add(Charset.forName("UTF-8")); // UTF-8
+        encodingsToTry.add(Charset.forName("UTF-16BE")); // UTF-16BE
+        encodingsToTry.add(Charset.forName("UTF-16LE")); // UTF-16LE
+        encodingsToTry.add(Charset.forName("UTF-32BE")); // UTF-32BE
+        encodingsToTry.add(Charset.forName("UTF-32LE")); // UTF-32LE
+        // ここに同じように追加すれば対応Charsetをいくらでも増やせるけど、
+        // 他の本体が対応できないためUTFのみにした方がよさそう。
+        
+        for (Charset encoding : encodingsToTry) {
+            try {
+                // CharsetDecoderを使用して、デコードエラー時に例外をスローするように設定する
+                CharsetDecoder decoder = encoding.newDecoder();
+                decoder.onMalformedInput(CodingErrorAction.REPORT);
+                decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+                                
+                // バイト列を文字列にデコードする
+                String decodedString = decoder.decode(ByteBuffer.wrap(bytes)).toString();
+
+                if (!(decodedString.contains("\r\n") || decodedString.contains("\r") || decodedString.contains("\n") || decodedString.contains("#"))) {
+                	// BMSファイル特有のチェック条件: 改行コードと"#"がないことはありえない
+                	continue; 
+                } else if (decodedString.contains("\ufffd")) {
+                	// REPLACEMENT CHARACTER が含まれていたらだめ(UTFの場合)
+                	continue;                	
+                }
+
+                // 文字列を再度Byte列化して比較。一致すれば文字化けが存在しないため、正しいエンコーディングと推測できる。
+                if (Arrays.equals(bytes, decodedString.getBytes(encoding))) {
+                    return encoding.name();
+                }
+
+            } catch (CharacterCodingException e) {
+            	// デコードエラー
+            	continue;
+            } catch (Exception e) {
+                // その他のエラー
+                continue;
+            }
+        }
+
+        // すべて試行して見つからなかった場合、デフォルトとしてMS932を返す
+        return "MS932";
+    }
+    
+    public String detectEncoding(byte[] bytes) {
+    	String encoding = encodingFromBOM(bytes) ;
+    	
+    	// BOMが存在しない場合
+    	if (encoding == "MS932" ){
+    		encoding = encodingFromGarbled(bytes);
+    	}
+    	
+    	return encoding;
     }
 }
 

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -512,9 +512,9 @@ public class BMSDecoder extends ChartDecoder {
     }
 
     /**
-     * 文字化けを調べて、Charsetを推測する。
+     * 文字化けを調べて、Charsetを推測する。BOMがないことが前提条件。
      * @param bytes Charsetを調べるByte列。
-     * @return 登録されているCharsetごとに、Byte列を文字列化した後さらにByte列に逆変換して、
+     * @return 登録されているCharsetごとにByte列と文字列のラウンドトリップ変換して、
      * 一致するなら、そのCharsetの名称。
      * 最後まで見つからなかったら、MS932を返す。
      */
@@ -540,16 +540,22 @@ public class BMSDecoder extends ChartDecoder {
                 	continue; 
                 }
 
-                // マルチバイト文字を途中で切ってしまうと文字化けするため、最後の文字を無視
-                if (decodedString != null && decodedString.length() > 1) {
-                    decodedString = decodedString.substring(0, decodedString.length() - 1);
+                byte[] newBytes = decodedString.getBytes(encoding);
+                int correctCount = 0;
+                int length = Math.min(bytes.length, newBytes.length);
+
+                // Byte列を比較して一致する連続個数をカウント
+               for (int i = 0; i < length; i++) {
+                    if (bytes[i] == newBytes[i]) {
+                    	correctCount++;
+                    } else {
+                    	break;
+                    }
                 }
                 
-                // バイト配列のサイズを文字列の逆変換後のサイズに調整
-                byte[] newBytes = Arrays.copyOf(bytes, decodedString.getBytes(encoding).length);
-                
-                // 文字列を再度Byte列化して比較。一致すれば文字化けが存在しないため、正しいエンコーディングと推測できる。
-                if (Arrays.equals(newBytes, decodedString.getBytes(encoding))) {
+                // 連続で閾値以上一致するなら、正しいエンコーディングと推測する。
+                // 末端に4バイト未満の欠落や文字化けが発生しうることを考慮
+                if (correctCount > bytes.length - 4) {
                     return encoding.name();
                 }
 

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -543,9 +543,6 @@ public class BMSDecoder extends ChartDecoder {
                 if (!(decodedString.contains("\r\n") || decodedString.contains("\r") || decodedString.contains("\n") || decodedString.contains("#"))) {
                 	// BMSファイル特有のチェック条件: 改行コードと"#"がないことはありえない
                 	continue; 
-                } else if (decodedString.contains("\ufffd")) {
-                	// REPLACEMENT CHARACTER が含まれていたらだめ(UTFの場合)
-                	continue;                	
                 }
 
                 // 文字列を再度Byte列化して比較。一致すれば文字化けが存在しないため、正しいエンコーディングと推測できる。

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -111,8 +111,8 @@ public class BMSDecoder extends ChartDecoder {
 		String encoding = "MS932";
 		// Detect the Encoding
 		try (FileInputStream fis = new FileInputStream(path.toFile())) {
-            byte[] bytes = new byte[1024];
-            fis.read(bytes, 0, 1024);
+            byte[] bytes = new byte[1024 * 64];
+            fis.read(bytes, 0, 1024 * 64); // 後ろの方に＃TITLEなどがある場合があるため多めに読み込ませる;64KBで十分
             encoding = detectEncoding(bytes);
 		} catch (IOException e) {
 			log.add(new DecodeLog(ERROR, "BMSファイルへのアクセスに失敗しました"));

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -520,8 +520,8 @@ public class BMSDecoder extends ChartDecoder {
      */
     public String encodingFromGarbled(byte[] bytes) {
         List<Charset> encodingsToTry = new ArrayList<>();
-        encodingsToTry.add(Charset.forName("MS932")); // SHIFT-JISは最優先する
         encodingsToTry.add(Charset.forName("EUC-KR")); // 韓国語環境のBMSEが出力するため2010年以前にしばしば見られた
+        encodingsToTry.add(Charset.forName("MS932")); // SHIFT-JIS
         encodingsToTry.add(Charset.forName("UTF-8")); // UTF-8
         encodingsToTry.add(Charset.forName("UTF-16BE")); // UTF-16BE
         encodingsToTry.add(Charset.forName("UTF-16LE")); // UTF-16LE

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -107,11 +107,30 @@ public class BMSDecoder extends ChartDecoder {
 			return null;
 		}
 
+		String encoding = "MS932";
+		// Detect the Encoding
+		try (FileInputStream fis = new FileInputStream(path.toFile())) {
+            byte[] bytes = new byte[4];
+            fis.read(bytes, 0, 4);
+            encoding = encodingFromBOM(bytes);
+		} catch (IOException e) {
+			log.add(new DecodeLog(ERROR, "BMSファイルへのアクセスに失敗しました"));
+			Logger.getGlobal()
+					.severe(path + ":BMSファイル解析失敗: " + e.getClass().getName() + " - " + e.getMessage());
+			return null;
+		} catch (Exception e) {
+			log.add(new DecodeLog(ERROR, "何らかの異常によりBMS解析に失敗しました"));
+			Logger.getGlobal()
+					.severe(path + ":BMSファイル解析失敗: " + e.getClass().getName() + " - " + e.getMessage());
+			e.printStackTrace();
+			return null;
+		}
+				
 		int maxsec = 0;
 		// BMS読み込み、ハッシュ値取得
 		try (BufferedReader br = new BufferedReader(new InputStreamReader(
 				new DigestInputStream(new DigestInputStream(new ByteArrayInputStream(data), md5digest), sha256digest),
-				"MS932"));) {
+				encoding));) {
 			model.setMode(ispms ? Mode.POPN_9K : Mode.BEAT_5K);
 			// Logger.getGlobal().info(
 			// "BMSデータ読み込み時間(ms) :" + (System.currentTimeMillis() - time));
@@ -440,6 +459,56 @@ public class BMSDecoder extends ChartDecoder {
 		}
 		return sb.toString();
 	}
+	
+    /**
+     * バイトオーダーマーク (BOM) に基づいてエンコーディングを推測します。
+     * 
+     * @param bytes チェックするバイト配列
+     * @return BOMに対応する文字コードを示す文字列。BOMが見つからない場合は"MS932"。
+     */
+    public static String encodingFromBOM(byte[] bytes) {
+
+        // BOM定義
+        final byte[] bomUTF8 = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+        final byte[] bomUTF16LE = {(byte) 0xFF, (byte) 0xFE};
+        final byte[] bomUTF16BE = {(byte) 0xFE, (byte) 0xFF};
+        final byte[] bomUTF32LE = {(byte) 0xFF, (byte) 0xFE, (byte) 0x00, (byte) 0x00};
+        final byte[] bomUTF32BE = {(byte) 0x00, (byte) 0x00, (byte) 0xFE, (byte) 0xFF};
+
+        // 4バイトチェック
+        if (bytes.length >= 4) {
+            byte[] prefix4 = Arrays.copyOf(bytes, 4);
+
+            if (Arrays.equals(prefix4, bomUTF32BE)) {
+                return "UTF-32BE";
+            } else if (Arrays.equals(prefix4, bomUTF32LE)) {
+                return "UTF-32LE";
+            }
+        }
+
+        // 3バイトチェック
+        if (bytes.length >= 3) {
+            byte[] prefix3 = Arrays.copyOf(bytes, 3);
+            
+            if (Arrays.equals(prefix3, bomUTF8)) {
+                return "UTF-8";
+            }
+        }
+
+        // 2バイトチェック
+        if (bytes.length >= 2) {
+            byte[] prefix2 = Arrays.copyOf(bytes, 2);
+
+            if (Arrays.equals(prefix2, bomUTF16BE)) {
+                return "UTF-16BE";
+            } else if (Arrays.equals(prefix2, bomUTF16LE)) {
+                return "UTF-16LE";
+            }
+        }
+
+        // BOMが見つからない場合、"MS932"を返す。
+        return "MS932";
+    }
 }
 
 /**

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -1,7 +1,6 @@
 package bms.model;
 
 import java.io.*;
-import java.nio.ByteBuffer;
 import java.nio.charset.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -523,7 +522,7 @@ public class BMSDecoder extends ChartDecoder {
         List<Charset> encodingsToTry = new ArrayList<>();
         encodingsToTry.add(Charset.forName("MS932")); // SHIFT-JISは最優先する
         encodingsToTry.add(Charset.forName("EUC-KR")); // 韓国語環境のBMSEが出力するため2010年以前にしばしば見られた
-		encodingsToTry.add(Charset.forName("UTF-8")); // UTF-8
+        encodingsToTry.add(Charset.forName("UTF-8")); // UTF-8
         encodingsToTry.add(Charset.forName("UTF-16BE")); // UTF-16BE
         encodingsToTry.add(Charset.forName("UTF-16LE")); // UTF-16LE
         encodingsToTry.add(Charset.forName("UTF-32BE")); // UTF-32BE
@@ -533,27 +532,27 @@ public class BMSDecoder extends ChartDecoder {
         
         for (Charset encoding : encodingsToTry) {
             try {
-                // CharsetDecoderを使用して、デコードエラー時に例外をスローするように設定する
-                CharsetDecoder decoder = encoding.newDecoder();
-                decoder.onMalformedInput(CodingErrorAction.REPORT);
-                decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
-                                
                 // バイト列を文字列にデコードする
-                String decodedString = decoder.decode(ByteBuffer.wrap(bytes)).toString();
+                String decodedString = new String(bytes, encoding);
 
                 if (!(decodedString.contains("\r\n") || decodedString.contains("\r") || decodedString.contains("\n") || decodedString.contains("#"))) {
                 	// BMSファイル特有のチェック条件: 改行コードと"#"がないことはありえない
                 	continue; 
                 }
 
+                // マルチバイト文字を途中で切ってしまうと文字化けするため、最後の文字を無視
+                if (decodedString != null && decodedString.length() > 1) {
+                    decodedString = decodedString.substring(0, decodedString.length() - 1);
+                }
+                
+                // バイト配列のサイズを文字列の逆変換後のサイズに調整
+                byte[] newBytes = Arrays.copyOf(bytes, decodedString.getBytes(encoding).length);
+                
                 // 文字列を再度Byte列化して比較。一致すれば文字化けが存在しないため、正しいエンコーディングと推測できる。
-                if (Arrays.equals(bytes, decodedString.getBytes(encoding))) {
+                if (Arrays.equals(newBytes, decodedString.getBytes(encoding))) {
                     return encoding.name();
                 }
 
-            } catch (CharacterCodingException e) {
-            	// デコードエラー
-            	continue;
             } catch (Exception e) {
                 // その他のエラー
                 continue;

--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -522,7 +522,8 @@ public class BMSDecoder extends ChartDecoder {
     public String encodingFromGarbled(byte[] bytes) {
         List<Charset> encodingsToTry = new ArrayList<>();
         encodingsToTry.add(Charset.forName("MS932")); // SHIFT-JISは最優先する
-        encodingsToTry.add(Charset.forName("UTF-8")); // UTF-8
+        encodingsToTry.add(Charset.forName("EUC-KR")); // 韓国語環境のBMSEが出力するため2010年以前にしばしば見られた
+		encodingsToTry.add(Charset.forName("UTF-8")); // UTF-8
         encodingsToTry.add(Charset.forName("UTF-16BE")); // UTF-16BE
         encodingsToTry.add(Charset.forName("UTF-16LE")); // UTF-16LE
         encodingsToTry.add(Charset.forName("UTF-32BE")); // UTF-32BE


### PR DESCRIPTION
ファイルの先頭4バイトからBOMを検出して、対応するUTFエンコーディングでBMSファイルを読み込ませます。
BOMがなければこれまで通りMS932を使用します。
簡易検出のためBOMなしUTFは判定していません。
その結果BOMなしUTF-8はMS932として読み込まれます。（文字化けを装ったMS932のタイトルが存在するため判定しづらい。）
BOMなしUTF16,32はコマンド行を認識できないため、譜面としての認識自体がされません。

テスト用データ：https://bms.ms/UnicodeTest.rar
