### PR TITLE
Set #BASE value before parsing the file

### DIFF
--- a/src/bms/model/BMSDecoder.java
+++ b/src/bms/model/BMSDecoder.java
@@ -126,7 +126,43 @@ public class BMSDecoder extends ChartDecoder {
 			e.printStackTrace();
 			return null;
 		}
-				
+		
+		// ファイルの最後まで読んで先に #BASE を確定することが必須
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data),encoding))) {
+			String line = null;
+			
+			while ((line = br.readLine()) != null) {
+				if (line.length() < 2) {
+					continue;
+				}
+				if(line.charAt(0) == '#') {
+					if (matchesReserveWord(line, "BASE")) {
+						if (line.charAt(5) == ' ') {
+							try {
+								final String arg = line.substring(6).trim();
+								int base = Integer.parseInt(arg);
+								if(base != 62 && base != 36 ) {
+									model.setBase(36);
+									log.add(new DecodeLog(WARNING, "#BASEに無効な数字が定義されています"));
+								} else {
+									model.setBase(base);
+								}
+							} catch (NumberFormatException e) {
+								model.setBase(36);
+								log.add(new DecodeLog(WARNING, "#BASEに数字が定義されていません"));
+							}
+						}
+					}
+				}
+			}	
+		} catch (IOException e) {
+			model.setBase(36);
+			log.add(new DecodeLog(ERROR, "BMSファイルへのアクセスに失敗しました"));
+			Logger.getGlobal()
+					.severe(path + ":BMSファイル解析失敗: " + e.getClass().getName() + " - " + e.getMessage());
+			e.printStackTrace();
+		}
+		
 		int maxsec = 0;
 		// BMS読み込み、ハッシュ値取得
 		try (BufferedReader br = new BufferedReader(new InputStreamReader(
@@ -726,18 +762,6 @@ enum CommandWord {
 	}),
 	COMMENT ((model, arg) -> {
 		// TODO 未実装
-		return null;
-	}),
-	BASE ((model, arg) -> {
-		try {
-			int base = Integer.parseInt(arg);
-			if(base != 62) {
-				return new DecodeLog(WARNING, "#BASEに無効な数字が定義されています");
-			}
-			model.setBase(base);
-		} catch (NumberFormatException e) {
-			return new DecodeLog(WARNING, "#BASEに数字が定義されていません");
-		}
 		return null;
 	});
 

--- a/src/bms/model/BMSModel.java
+++ b/src/bms/model/BMSModel.java
@@ -595,6 +595,5 @@ public class BMSModel implements Comparable<BMSModel> {
 		} else {
 			this.base = 36;
 		}
-		return;
 	}
 }


### PR DESCRIPTION
この変更は、ファイル定義の後に #BASE 62 が書かれるとそれが実際に62進数であるかないかにかかわらず正常に再生できなくなる問題を解決します。

これまでは #BASE 62 が出現したタイミングで62進数に切り替わっていたため、出現の前後で10番以降の定義番号が異なった10進数に変換されてしまっていました。
変更後はファイルをパースする前にファイルの最後まで読んで62進数判定を行うことで、#BASE 62 がどこに書かれても正常に再生できるようになります。

ちなみにその現象はBMSE2.xの62進数モードとμBMSCを併用してしまった場合に起こります。BMSE側では3.0にて修正しています。

確認用の小さく短いデータとしてyamajet氏の(^^)を元にテスト用のデータを作成しました。
音声を10番以降に定義してファイル定義とデータ部の間に #BASE 62 を記述してあります。
https://bms.ms/postBase62Test.zip